### PR TITLE
Typo fix (syx-tank-750-cone-1.cfg)

### DIFF
--- a/GameData/SpaceY/SpaceYExpanded/Parts/FuelTanks/syx-tank-750-cone-1.cfg
+++ b/GameData/SpaceY/SpaceYExpanded/Parts/FuelTanks/syx-tank-750-cone-1.cfg
@@ -48,7 +48,7 @@ PART
 
 	maxTemp = 2400
 
-	FuelVolume = 191520 // 16200
+	FuelVolume = 19152 // 16200
 	RESOURCE
 	{
 		name = LiquidFuel


### PR DESCRIPTION
I assume the decimal place just landed in the wrong spot.

Note sure if `FuelVolume` is used in-game, or is purely decorative, but figured it was worth a fix anyway.